### PR TITLE
[SUGGESTION] Use official GitHub API instead of the timeline.

### DIFF
--- a/crawler/crawler.rb
+++ b/crawler/crawler.rb
@@ -57,7 +57,7 @@ EM.run do
   end
 
   process = Proc.new do
-      req = HttpRequest.new("https://github.com/timeline.json").get({
+      req = HttpRequest.new("https://api.github.com/events").get({
       :head => {
         'user-agent' => 'archiver.io'
       }


### PR DESCRIPTION
Hey Ilya,
the main reason to use official API instead of the timeline would be the fact that API is documented and it shouldn't change whereas timeline is not and I've got a feeling that it might change more often than you'd like to.

On the other hand, objects returned from the timeline are a bit different from those returned from the API - they contain evaluated `"repository"` and `"actor"` objects, but they're missing numeric `"id"`... Personally, I cannot decide which is better for long-term archival & analysis.

I'm aware that this change would require wiping already collected data, that's why I wanted to bring this to your attention as soon as possible.

Timeline object:

```
{
    "repository": {
        "url": "https://github.com/PiotrSikora/githubarchive.org",
        "has_wiki": false,
        "homepage": "http://www.githubarchive.org",
        "open_issues": 0,
        "watchers": 1,
        "pushed_at": "2012/03/13 17:34:50 -0700",
        "fork": true,
        "language": "Ruby",
        "size": 112,
        "private": false,
        "has_downloads": true,
        "name": "githubarchive.org",
        "owner": "PiotrSikora",
        "has_issues": false,
        "created_at": "2012/03/13 01:10:37 -0700",
        "forks": 0,
        "description": "GitHub Archive is a project to record the public GitHub timeline, archive it, and make it easily accessible for further analysis."
    },
    "actor_attributes": {
        "name": "Piotr Sikora",
        "company": "FRiCKLE",
        "gravatar_id": "61d4fa1ae5cd5b1cc7ccf1298c4d422b",
        "location": "Poland",
        "blog": "http://www.frickle.com/",
        "type": "User",
        "login": "PiotrSikora",
        "email": "piotr.sikora@frickle.com"
    },
    "created_at": "2012/03/13 17:34:51 -0700",
    "public": true,
    "actor": "PiotrSikora",
    "payload": {
        "master_branch": "master",
        "ref_type": "branch",
        "description": "GitHub Archive is a project to record the public GitHub timeline, archive it, and make it easily accessible for further analysis.",
        "ref": "events"
    },
    "url": "https://github.com/PiotrSikora/githubarchive.org/compare/events",
    "type": "CreateEvent"
}
```

Events object:

```
{
    "type": "CreateEvent",
    "org": {
        "url": "https://api.github.com/orgs/"
    },
    "public": true,
    "payload": {
        "master_branch": "master",
        "ref": "events",
        "description": "GitHub Archive is a project to record the public GitHub timeline, archive it, and make it easily accessible for further analysis.",
        "ref_type": "branch"
    },
    "repo": {
        "url": "https://api.github.com/repos/PiotrSikora/githubarchive.org",
        "id": 3704443,
        "name": "PiotrSikora/githubarchive.org"
    },
    "actor": {
        "url": "https://api.github.com/users/PiotrSikora",
        "gravatar_id": "61d4fa1ae5cd5b1cc7ccf1298c4d422b",
        "id": 190297,
        "login": "PiotrSikora"
    },
    "created_at": "2012-03-14T00:34:51Z",
    "id": "1529753953"
}
```
