### PR TITLE
web: Fix download examples

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -76,11 +76,11 @@
               </tr>
               <tr>
                 <td>Activity for March 11, 2012</td>
-                <td><code>wget http://data.githubarchive.org/2012-03-11-{0..24}.json.gz</code></td>
+                <td><code>wget http://data.githubarchive.org/2012-03-11-{0..23}.json.gz</code></td>
               </tr>
               <tr>
                 <td>Activity for March 2012</td>
-                <td><code>wget http://data.githubarchive.org/2012-03-{0..30}-{0..24}.json.gz</code></td>
+                <td><code>wget http://data.githubarchive.org/2012-03-{01..31}-{0..23}.json.gz</code></td>
               </tr>
             </tbody>
             </table>


### PR DESCRIPTION
- Hours are from 0 to 23, without leading zero
- Days (in March) are from 1 to 31, with leading zero

Please note that you should change the last example to "Activity for April 2012" at the end of April, because downloading all events that happened on March won't work, because githubarchive only started in the middle of March.
