### PR TITLE
There are now 18 event types

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Open-source developers all over the world are working on millions of projects: w
 
 ----
 
-GitHub provides 17 event types, which range from new commits and fork events, to opening new tickets, commenting, and adding members to a project. The activity is aggregated in hourly archives, which you can access with any HTTP client:
+GitHub provides [18 event types](http://developer.github.com/v3/events/types/), which range from new commits and fork events, to opening new tickets, commenting, and adding members to a project. The activity is aggregated in hourly archives, which you can access with any HTTP client:
 
 <table>
 <thead>

--- a/web/index.html
+++ b/web/index.html
@@ -60,7 +60,7 @@
       <div class="row">
         <div class="span12">
 
-           <p style="font-size:16px; line-height:25px">GitHub provides <a href="http://developer.github.com/v3/events/types/">17 event types</a>, which range from new commits and fork events, to opening new tickets, commenting, and adding members to a project. The activity is aggregated in hourly archives, which you can access with any HTTP client:</p>
+           <p style="font-size:16px; line-height:25px">GitHub provides <a href="http://developer.github.com/v3/events/types/">18 event types</a>, which range from new commits and fork events, to opening new tickets, commenting, and adding members to a project. The activity is aggregated in hourly archives, which you can access with any HTTP client:</p>
 
            <table class="table table-striped">
             <thead>


### PR DESCRIPTION
I hope you don't mind me pointing out tiny errors, but I just stumbled upon this when my parser was complaining about an unknown event type, even though I already added 17 different event types.

The "PullRequestReviewCommentEvent" was added to the documentation on March 20th (github/developer.github.com@85e48dafedc6e3f925f7ef23fd86eea3aee32bc8), but it must have been added to the timeline earlier than that, because githubarchive files from March 11th already contain this event type.
