### PR TITLE
Github button URL changed in a way that it breaks the website for anyone w/ JavaScript

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -40,7 +40,7 @@
         GitHub <span style="color:#c60000">Archive</span>
 
         <span style="float:right; margin-top:0.25em">
-	  <iframe src="http://markdotto.github.com/github-buttons/github-btn.html?user=igrigorik&repo=githubarchive.org&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110px" height="20px"></iframe>
+	  <iframe src="http://ghbtns.com/github-btn.html?user=igrigorik&repo=githubarchive.org&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110px" height="20px"></iframe>
           <g:plusone size="medium"></g:plusone>
           <a href="https://twitter.com/share" class="twitter-share-button" data-text="GitHub public timeline archive @ " data-related="igrigorik">Tweet</a>
         </span>
@@ -120,7 +120,7 @@
         <p>
           <a href="http://www.igvita.com" rel="me" style="vertical-align:top; margin-right:1em"><strong>Ilya Grigorik</strong></a>
           <span style="float:right;">
-	    <iframe src="http://markdotto.github.com/github-buttons/github-btn.html?user=igrigorik&type=follow&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="165px" height="20px" style="margin-right:1em"></iframe>
+	    <iframe src="http://ghbtns.com/github-btn.html?user=igrigorik&type=follow&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="165px" height="20px" style="margin-right:1em"></iframe>
             <a href="https://twitter.com/igrigorik" class="twitter-follow-button" data-show-count="true">Follow @igrigorik</a>
           </span>
         </p>


### PR DESCRIPTION
The github button moved from markdotto.github.com to ghbtns.com, and the old
URL simply 404ed. However, the Github Pages 404 page may not be used within a
frame/iframe, so when JavaScript is enabled, it would display an error message
and remove the outer frame by redirecting to itself. Thus, any visitor to
githubarchive.org with JavaScript enabled would be redirected to a Github Pages
404 page.

My commit simply changes the two buttons on the website to the new URL.
