### PR TITLE
Fixed link to Github API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Looking for the [daily top new & watched repository](http://us5.campaign-archive
 
 ----
 
-GitHub provides [18 event types](http://developer.github.com/v3/events/types/), which range from new commits and fork events, to opening new tickets, commenting, and adding members to a project. The activity is aggregated in hourly archives, which you can access with any HTTP client:
+GitHub provides [18 event types](http://developer.github.com/v3/activity/events/types/), which range from new commits and fork events, to opening new tickets, commenting, and adding members to a project. The activity is aggregated in hourly archives, which you can access with any HTTP client:
 
 <table>
 <thead>


### PR DESCRIPTION
As part of http://24pullrequests.com, giving back little gifts of code for Christmas.
