### PR TITLE
Add two more BigQuery examples for calculating useful statistics

### DIFF
--- a/bigquery/README.md
+++ b/bigquery/README.md
@@ -69,6 +69,25 @@ WHERE type="PushEvent"
   )
   AND PARSE_UTC_USEC(created_at) >= PARSE_UTC_USEC('2012-04-20 00:00:00')
 ORDER BY timestamp DESC
+
+/* top 100 repos by total number of forks, for a specific date rage */
+SELECT repository_url, MAX(repository_forks) as total_number_of_forks
+FROM [githubarchive:github.timeline]
+WHERE
+    PARSE_UTC_USEC(created_at) >= PARSE_UTC_USEC("2012-03-15 00:00:00") AND
+    PARSE_UTC_USEC(created_at) < PARSE_UTC_USEC("2012-03-16 00:00:00")
+GROUP BY repository_url
+ORDER BY total_number_of_forks DESC
+LIMIT 100
+
+/* month-by-month count of push events for Go */
+SELECT LEFT(created_at, 7) as month, COUNT(*) as pushes
+FROM [githubarchive:github.timeline]
+WHERE
+    type='PushEvent' AND
+    repository_language='Go'
+GROUP BY month
+ORDER BY month DESC
 ```
 
 For full schema of available fields to select, order, and group by, see schema.js.


### PR DESCRIPTION
Hi Ilya, 

I really like the BigQuery examples in the README, they've been very helpful when I started playing with githubarchive in BigQuery. I've added two new examples that I've found people often need but have trouble with writing them themselves:

1) Fetching the top N repos by fork/watches count for a specific date range. This query orders the repos not by the number of forks that happened in that range, but rather by the maximum total number of forks that the repository had in that range.

2) Fetching the month-by-month number of events (by type) for a specific repository/language. This is really cool since it allows people to get timeline statistics with just a single query. The query is easily modified to do a day-by-day count by using `LEFT(created_at, 10)` instead of `LEFT(created_at, 7)`.
