### PR TITLE
[index.html] Events are from UTC times, not PST

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -83,7 +83,7 @@
             </thead>
             <tbody>
               <tr>
-                <td>Activity for April 11, 2012, 7AM PST</td>
+                <td>Activity for April 11, 2012, 3PM UTC</td>
                 <td><code>wget http://data.githubarchive.org/2012-04-11-15.json.gz</code></td>
               </tr>
               <tr>


### PR DESCRIPTION
Looking at e.g. http://data.githubarchive.org/2012-03-08-0.json.gz

All events within that dataset have timestamps from 
"2012-03-08 00:00:00 UTC" through
"2012-03-08 00:59:59 UTC".

The main page says the dataset should have been cut at midnight PST (-08:00), which, if true, would make the events have event.created_at from "2012-03-08 08:00:00 UTC" to "2012-03-08 08:59:59 UTC".
