### PR TITLE
Add Ÿ HŸPE service to the list of resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,6 +195,7 @@
             <li><a href="https://github.com/vitalets/github-trending-repos">GitHub Trending Repos</a> - Stay notified about new trending repositories in your favorite programming language via GitHub notifications.</li>
             <li><a href="https://github.com/cncf/devstats">DevStats</a> - CNCF-created tool for analyzing and graphing developer contributions</li>
             <li><a href="https://gh.clickhouse.tech/explorer/">GH Explorer</a> - GitHub insights on ClickHouse (structured dataset for download + interactive queries)</li>
+            <li><a href="https://yhype.me">Ÿ HŸPE</a> - Personal GitHub analytics on steroids (profile views, stars & followages history, repository traffic data with extended lifetime).</li>
           </ul>
 
           <p>Have a cool project that should be on this list? <a href="https://github.com/igrigorik/gharchive.org/tree/gh-pages">Send a pull request</a>!</p>


### PR DESCRIPTION
Some historical data is not available on GitHub (followages history, stars history, repository traffic has limited lifetime, no profile views information). I've created a publicly available service https://yhype.me which may fill the gap.

![Screenshot_2021-03-31 Ÿ HŸPE(3)](https://user-images.githubusercontent.com/1849174/113428298-3ae4df00-93df-11eb-9b84-52751273b07e.png)

