### PR TITLE
Instructions and early exception

### DIFF
--- a/crawler/README.md
+++ b/crawler/README.md
@@ -6,6 +6,16 @@ For details on how to fetch the archived data, see www.gharchive.org.
 
 ## Install
 
+You may need to install openssl to install eventmachine correctly.
+
+```sh
+sudo apt-get install openssl-dev
+OR
+sudo dnf install openssl-devel
+```
+
+Then you can install the ruby gems like so:
+
 ```sh
 gem install bundler:1.16.1
 bundle install

--- a/crawler/README.md
+++ b/crawler/README.md
@@ -3,3 +3,10 @@
 GitHub activities are archived by periodically polling the [Events API](https://developer.github.com/v3/activity/events/) and archiving the raw responses into hourly archives - i.e. no additional post processing is done.
 
 For details on how to fetch the archived data, see www.gharchive.org.
+
+## Install
+
+```
+gem install bundler:1.16.1
+bundle install
+```

--- a/crawler/README.md
+++ b/crawler/README.md
@@ -6,7 +6,13 @@ For details on how to fetch the archived data, see www.gharchive.org.
 
 ## Install
 
-```
+```sh
 gem install bundler:1.16.1
 bundle install
+```
+
+## Run Crawler
+
+```sh
+bundle exec ruby crawler.rb
 ```

--- a/crawler/crawler.rb
+++ b/crawler/crawler.rb
@@ -22,6 +22,11 @@ end
   :formatter => Log4r::PatternFormatter.new(:pattern => "[#{Process.pid}:%l] %d :: %m")
 }))
 
+if !ENV['GITHUB_TOKEN']
+  @log.error "No GITHUB_TOKEN environment variable defined."
+  raise "No GITHUB_TOKEN environment variable defined."
+end
+
 ##
 ## Crawler
 ##


### PR DESCRIPTION
Update crawler README with install and run instructions and return error if GITHUB_TOKEN is not found.