### PR TITLE
Remove unused Procfile

### DIFF
--- a/crawler/Procfile
+++ b/crawler/Procfile
@@ -1,1 +1,0 @@
-crawler: bundle exec ruby crawler.rb


### PR DESCRIPTION
If I'm understanding it correctly, the procfile is used by Heroku, but we are hosting this project on GCP, so it should be safe to remove this file.

If the file is useful, please let me know and I'll add a note somewhere.