### PR TITLE
Switch order for exception logs

### DIFF
--- a/crawler/crawler.rb
+++ b/crawler/crawler.rb
@@ -93,8 +93,10 @@ EM.run do
         StatHat.new.ez_count('Github Events', new_events.size)
 
       rescue Exception => e
+        @log.error "Failed to process response"
+        @log.error "Response: #{req.response}"
+        @log.error "Response headers: #{req.response_header}"
         @log.error "Processing exception: #{e}, #{e.backtrace.first(5)}"
-        @log.error "Response: #{req.response_header}, #{req.response}"
       ensure
         EM.add_timer(0.75, &process)
       end


### PR DESCRIPTION
When running the crawler locally I ran into some issues and the output was shrouded by the API response, heading the useful output of the exception.

This change lows the request response, the headers and finally the exception details.

This is more helpful for run time debugging but may be less helpful for historical log viewing, so feel free to close if you've found this ordering to be helpful.