### PR TITLE
Add OSS Insight to showcase

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,6 +195,7 @@
             <li><a href="https://github.com/vitalets/github-trending-repos">GitHub Trending Repos</a> - Stay notified about new trending repositories in your favorite programming language via GitHub notifications.</li>
             <li><a href="https://github.com/cncf/devstats">DevStats</a> - CNCF-created tool for analyzing and graphing developer contributions</li>
             <li><a href="https://gh.clickhouse.tech/explorer/">GH Explorer</a> - GitHub insights on ClickHouse (structured dataset for download + interactive queries)</li>
+            <li><a href="https://ossinsight.io/">OSS Insight</a> - Open Source Software Insights - analysis, comparison, trends, rankings of open source software, based on TiDB Cloud</li>
           </ul>
 
           <p>Have a cool project that should be on this list? <a href="https://github.com/igrigorik/gharchive.org/tree/gh-pages">Send a pull request</a>!</p>


### PR DESCRIPTION
HI, we built https://ossinsight.io based on GH Archive project, thanks a lot for providing historical GitHub events data.

Now the OSS Insight project is ready, we want to show it in showcase page.

Thanks again.