### PR TITLE
fix: PAGE_LIMIT to 100 events (crawler)

### DIFF
--- a/crawler/crawler.rb
+++ b/crawler/crawler.rb
@@ -12,7 +12,7 @@ include EM
 ## Setup
 ##
 
-PAGE_LIMIT = 200
+PAGE_LIMIT = 100
 
 StatHat.config do |c|
   c.ukey  = ENV['STATHATKEY']


### PR DESCRIPTION
Currently `PAGE_LIMIT` is `200` which does not match [the GitHub REST API documentation](https://docs.github.com/en/rest/activity/events#list-public-events):
> `per_page` integer
> The number of results per page (max 100).
> Default: `30`

Because GitHub defaults to the maximum allowed value (100) when a larger value is specified, there is no impact of the current incorrect value. This can be confirmed by directly hitting the API with the current value and only 100 records are returned:
```
$ curl -sH "Authorization: token $GITHUB_TOKEN" "https://api.github.com/events?per_page=200" | jq length
100
```
However, the constant is also used to detect when events are dropped/missed: https://github.com/igrigorik/gharchive.org/blob/master/crawler/crawler.rb#L86-L88
```ruby
if new_events.size >= PAGE_LIMIT
    @log.info "Missed records.."
end
```
As a result the crawler will never log that is has missed events even when it has (because `100 >= 200` will never be true).