### PR TITLE
fix link in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
 
       <div class="row">
         <div class="span12">
-           <p>GitHub provides <a href="https://developer.github.com/v3/activity/events/types/">20+ event types</a>, which range from new commits and fork events, to opening new tickets, commenting, and adding members to a project. These events are aggregated into hourly archives, which you can access with any HTTP client:</p>
+           <p>GitHub provides <a href="https://docs.github.com/en/webhooks-and-events/events/github-event-types">20+ event types</a>, which range from new commits and fork events, to opening new tickets, commenting, and adding members to a project. These events are aggregated into hourly archives, which you can access with any HTTP client:</p>
 
            <table class="table table-striped">
             <thead>


### PR DESCRIPTION
the link to the event types on GitHub seems to be redirecting to the wrong site