### PR TITLE
Add research paper

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,6 +164,7 @@
           <br/>
 
           <ul>
+            <li><a href="https://ieeexplore.ieee.org/abstract/document/10207085">Technical Debt Classification in Issue Trackers using Natural Language Processing based on Transformers</a> - machine learning model that can be used to classify GitHub issues as technical debt or not. All source code is freely available on <a href="https://zenodo.org/record/7225077">Zenodo</a>.</li>
             <li><a href="https://www.baresquare.com/github-devtrends/">GitHub DevTrends</a> is a freely available dynamic report for the developer community based on trends identified from GitHub data.</a></li>
             <li><a href="https://opensourceindex.io/">Open Source Contributor Index</a> (OSCI) - a tool that ranks the top open source contributors by commercial organizations.</a></li>
             <li><a href="https://blog.antoine-augusti.fr/2019/04/analysing-commits-on-github-by-gouv-fr-authors/">Analysing commits on github by @.gouv.fr authors</a> - how French public servants publish and contribute to open source projects on GitHub</a></li>


### PR DESCRIPTION
Adding research paper, which used GH Archive to build machine learning models to classify issues as either technical debt or not:

[D. Skryseth, K. Shivashankar, I. Pilán and A. Martini, "Technical Debt Classification in Issue Trackers using Natural Language Processing based on Transformers," 2023 ACM/IEEE International Conference on Technical Debt (TechDebt), Melbourne, Australia, 2023, pp. 92-101, doi: 10.1109/TechDebt59074.2023.00017.](https://ieeexplore.ieee.org/abstract/document/10207085)

To list of [Research, visualizations, talks...](file:///c%3A/Users/dansk/Documents/GitHub/gharchive.org/index.html#resources).