### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,6 +203,7 @@
             <li>Datasets Guide: <a href="https://soulteary.com/2023/02/23/exploring-github-open-datasets.html">How to get the Complete GH Archive Dataset quickly.</a></li>
             <li><a href="https://github.com/fxgst/ghelephant">GH Elephant</a> creates a relational Postgres database from GH Archive's JSONs for faster queries in SQL.</li>
             <li><a href="https://doi.org/10.3929/ethz-b-000612634">Master's thesis</a> analyzing developers' intentions to make open-source software GDPR compliant</li>
+            <li><a href="https://ghfeed.org">GHFeed</a> monitor newly committed files in GitHub in real-time</li>
           </ul>
 
           <p>Have a cool project that should be on this list? <a href="https://github.com/igrigorik/gharchive.org/tree/gh-pages">Send a pull request</a>!</p>


### PR DESCRIPTION
Adding a link to ghfeed.org. Motivated by gharchive.org, GH Feed is a project to monitor newly committed files in GitHub, archive them, and make them easily accessible for further analysis.