### PR TITLE
add OSO to gharchive index

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,6 +205,7 @@
             <li>Datasets Guide: <a href="https://soulteary.com/2023/02/23/exploring-github-open-datasets.html">How to get the Complete GH Archive Dataset quickly.</a></li>
             <li><a href="https://github.com/fxgst/ghelephant">GH Elephant</a> creates a relational Postgres database from GH Archive's JSONs for faster queries in SQL.</li>
             <li><a href="https://doi.org/10.3929/ethz-b-000612634">Master's thesis</a> analyzing developers' intentions to make open-source software GDPR compliant</li>
+            <li><a href="https://www.opensource.observer">Open Source Observer</a> - a free analytics suite that helps funders measure the impact of open source software contributions to the health of their ecosystem.</li>
           </ul>
 
           <p>Have a cool project that should be on this list? <a href="https://github.com/igrigorik/gharchive.org/tree/gh-pages">Send a pull request</a>!</p>


### PR DESCRIPTION
We are building out a variety of impact metrics to track open source contributions. Check out our docs and blog for some ideas. We'll have more [data visualizations](https://www.opensource.observer/project/opensource-observer) up on our website too soon!

